### PR TITLE
ストライプ チリチリ 川　めまい タイムマシン　を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,31 @@
                 <i class="form-icon"></i>
                 ネオン
               </label>
+              <label class="form-checkbox form-inline">
+                <input type="checkbox" class="JS_effect" value="effect_stripe">
+                <i class="form-icon"></i>
+                ストライプ
+              </label>
+              <label class="form-checkbox form-inline">
+                <input type="checkbox" class="JS_effect" value="effect_tiritiri">
+                <i class="form-icon"></i>
+                チリチリ
+              </label>
+              <label class="form-checkbox form-inline">
+                <input type="checkbox" class="JS_effect" value="effect_river">
+                <i class="form-icon"></i>
+                川
+              </label>
+              <label class="form-checkbox form-inline">
+                <input type="checkbox" class="JS_effect" value="effect_dizzy">
+                <i class="form-icon"></i>
+                めまい
+              </label>
+              <label class="form-checkbox form-inline">
+                <input type="checkbox" class="JS_effect" value="effect_timeMachine">
+                <i class="form-icon"></i>
+                タイムマシン
+              </label>
             </div>
             <div id="JS_details" class="card" style="display: none">
               <div class="card-body">

--- a/index.html
+++ b/index.html
@@ -221,6 +221,16 @@
                 ネオン
               </label>
               <label class="form-checkbox form-inline">
+                <input type="checkbox" class="JS_effect" value="effect_psych">
+                <i class="form-icon"></i>
+                サイケ
+              </label>
+              <label class="form-checkbox form-inline">
+                <input type="checkbox" class="JS_effect" value="effect_check">
+                <i class="form-icon"></i>
+                チェック
+              </label>
+              <label class="form-checkbox form-inline">
                 <input type="checkbox" class="JS_effect" value="effect_stripe">
                 <i class="form-icon"></i>
                 ストライプ
@@ -234,6 +244,11 @@
                 <input type="checkbox" class="JS_effect" value="effect_river">
                 <i class="form-icon"></i>
                 川
+              </label>
+              <label class="form-checkbox form-inline">
+                <input type="checkbox" class="JS_effect" value="effect_signedBall">
+                <i class="form-icon"></i>
+                サインボール
               </label>
               <label class="form-checkbox form-inline">
                 <input type="checkbox" class="JS_effect" value="effect_dizzy">

--- a/megamoji.js
+++ b/megamoji.js
@@ -252,68 +252,165 @@ function effect_zoom (keyframe, ctx, cellWidth, cellHeight) {
 }
 
 function effect_tiritiri (keyframe, ctx, cellWidth, cellHeight) {
-    bgColorRGB = [
-        parseInt(ctx.fillStyle.substring(1, 3), 16),
-        parseInt(ctx.fillStyle.substring(3, 5), 16),
-        parseInt(ctx.fillStyle.substring(5, 7), 16)
-    ]
-    const parentLayerRGBA = getImageDataFourDimension(ctx, cellWidth, cellHeight)
-    secondLayerImageData = restoreUint8ClampedArray(
-        parentLayerRGBA.map(function(element, index, array) {
-            return bgColorRGB.concat(parseInt(255 * Math.random()));
-        })
-    )
-    secondLayer = new ImageData(secondLayerImageData, cellWidth, cellHeight)
-    ctx.putImageData(secondLayer, 0, 0)
+    var image_data = ctx.getImageData(0, 0, cellWidth, cellHeight);
+    var data = image_data.data;
+    for (var row = 0; row < cellHeight; row++) {
+        for (var col = 0; col < cellWidth; col++) {
+            data[(row * cellWidth + col) * 4 + 3] = parseInt(255 * Math.random());
+        }
+    }
+    ctx.putImageData(image_data, 0, 0);
 }
 
 function effect_stripe (keyframe, ctx, cellWidth, cellHeight) {
-    const parentLayerRGBA = getImageDataFourDimension(ctx, cellWidth, cellHeight)
-    secondLayerImageData = restoreUint8ClampedArray(
-        parentLayerRGBA.map(function(element, index, array) {
-            return (index % cellHeight) % 3 == 1 ? [0, 0, 0, 0] : element;
-        })
-    )
-    secondLayer = new ImageData(secondLayerImageData, cellWidth, cellHeight)
-    ctx.putImageData(secondLayer, 0, 0)
+    var image_data = ctx.getImageData(0, 0, cellWidth, cellHeight);
+    var data = image_data.data;
+    for (var row = 0; row < cellHeight; row++) {
+        for (var col = 0; col < cellWidth; col++) {
+            if (col % 3 === 1)  {
+                data[(row * cellWidth + col) * 4 + 3] = 0;
+            }
+        }
+    }
+    ctx.putImageData(image_data, 0, 0);
 }
 
 function effect_river (keyframe, ctx, cellWidth, cellHeight) {
-    bgColorHSV = rgb2hsv(
-        parseInt(ctx.fillStyle.substring(1, 3), 16),
-        parseInt(ctx.fillStyle.substring(3, 5), 16),
-        parseInt(ctx.fillStyle.substring(5, 7), 16)
-    )
-    const parentLayerRGBA = getImageDataFourDimension(ctx, cellWidth, cellHeight)
-    secondLayerImageData = restoreUint8ClampedArray(
-        parentLayerRGBA.map(function(element, index, array) {
-            return (index+(keyframe*40)) % 40 < 40 && (index+(keyframe*40)) % 40 > 20 ? hsvToRgb(bgColorHSV["h"]+180, 1, 1).concat(255) : element;
-        })
-    )
-    secondLayer = new ImageData(secondLayerImageData, cellWidth, cellHeight)
-    ctx.putImageData(secondLayer, 0, 0)
+    var bgColorHSV = rgb2hsv(
+            parseInt(ctx.fillStyle.substring(1, 3), 16),
+            parseInt(ctx.fillStyle.substring(3, 5), 16),
+            parseInt(ctx.fillStyle.substring(5, 7), 16)
+        )
+    var image_data = ctx.getImageData(0, 0, cellWidth, cellHeight);
+    var data = image_data.data;
+    for (var row = 0; row < (cellHeight * cellWidth * 4); row = row + 4) {
+        if ((row / 4 + (keyframe * 40)) % 40 < 40 && (row / 4 + (keyframe*40)) % 40 > 20) {
+            var color = hsvToRgb(bgColorHSV["h"] + 180, 1, 1);
+            data[row] = color[0];
+            data[row + 1] = color[1];
+            data[row + 2] = color[2];
+        }
+    }
+    ctx.putImageData(image_data, 0, 0);
+}
+
+function effect_signedBall (keyframe, ctx, cellWidth, cellHeight) {
+    var bgColorHSV = rgb2hsv(
+            parseInt(ctx.fillStyle.substring(1, 3), 16),
+            parseInt(ctx.fillStyle.substring(3, 5), 16),
+            parseInt(ctx.fillStyle.substring(5, 7), 16)
+        )
+    var image_data = ctx.getImageData(0, 0, cellWidth, cellHeight);
+    var data = image_data.data;
+    for (var row = 0; row < cellHeight; row++) {
+        for (var col = 0; col < cellWidth; col++) {
+            if ((row + col + (keyframe * 40)) % 40 < 40 && (row + col + (keyframe*40)) % 40 > 20) {
+                var color = hsvToRgb(bgColorHSV["h"] + 180, 1, 1);
+                data[(row * cellWidth + col) * 4] = color[0];
+                data[(row * cellWidth + col) * 4 + 1] = color[1];
+                data[(row * cellWidth + col) * 4 + 2] = color[2];
+            }
+        }
+    }
+    ctx.putImageData(image_data, 0, 0);
+}
+
+function effect_psych (keyframe, ctx, cellWidth, cellHeight) {
+    var bgColorHSV = rgb2hsv(
+            parseInt(ctx.fillStyle.substring(1, 3), 16),
+            parseInt(ctx.fillStyle.substring(3, 5), 16),
+            parseInt(ctx.fillStyle.substring(5, 7), 16)
+        )
+    var image_data = ctx.getImageData(0, 0, cellWidth, cellHeight);
+    var data = image_data.data;
+    for (var row = 0; row < cellHeight; row++) {
+        for (var col = 0; col < cellWidth; col++) {
+            if (row % 10 <= 5 && col % 10 >= 5) {
+                var color = hsvToRgb((keyframe * 360 * 4 + 180)%360, 1, 1);
+                data[(row * cellWidth + col) * 4] = color[0];
+                data[(row * cellWidth + col) * 4 + 1] = color[1];
+                data[(row * cellWidth + col) * 4 + 2] = color[2];
+                data[(row * cellWidth + col) * 4 + 3] = 255;
+            } else if (row % 10 < 5 ^ col % 10 < 5) {
+                var color = hsvToRgb((keyframe * 360 * 4 + 90)%360, 1, 1);
+                data[(row * cellWidth + col) * 4] = color[0];
+                data[(row * cellWidth + col) * 4 + 1] = color[1];
+                data[(row * cellWidth + col) * 4 + 2] = color[2];
+                data[(row * cellWidth + col) * 4 + 3] = 255;
+            } else {
+                var color = hsvToRgb((keyframe * 360 * 4)%360, 1, 1);
+                data[(row * cellWidth + col) * 4] = color[0];
+                data[(row * cellWidth + col) * 4 + 1] = color[1];
+                data[(row * cellWidth + col) * 4 + 2] = color[2];
+                data[(row * cellWidth + col) * 4 + 3] = 255;
+            }
+        }
+    }
+    ctx.putImageData(image_data, 0, 0);
+}
+
+function effect_check (keyframe, ctx, cellWidth, cellHeight) {
+    var bgColorHSV = rgb2hsv(
+            parseInt(ctx.fillStyle.substring(1, 3), 16),
+            parseInt(ctx.fillStyle.substring(3, 5), 16),
+            parseInt(ctx.fillStyle.substring(5, 7), 16)
+        )
+    var image_data = ctx.getImageData(0, 0, cellWidth, cellHeight);
+    var data = image_data.data;
+    for (var row = 0; row < cellHeight; row++) {
+        for (var col = 0; col < cellWidth; col++) {
+            if (row % 16 <= 8 && col % 16 >= 8) {
+                var color = hsvToRgb(bgColorHSV['h'], 1, 0.8);
+                data[(row * cellWidth + col) * 4] = color[0];
+                data[(row * cellWidth + col) * 4 + 1] = color[1];
+                data[(row * cellWidth + col) * 4 + 2] = color[2];
+                data[(row * cellWidth + col) * 4 + 3] = 255;
+            } else if (row % 16 < 8 ^ col % 16 < 8) {
+                var color = hsvToRgb(bgColorHSV['h'], 1, 1);
+                data[(row * cellWidth + col) * 4] = color[0];
+                data[(row * cellWidth + col) * 4 + 1] = color[1];
+                data[(row * cellWidth + col) * 4 + 2] = color[2];
+                data[(row * cellWidth + col) * 4 + 3] = 255;
+            } else {
+               var color = hsvToRgb(bgColorHSV['h'], 1, 0.5);
+               data[(row * cellWidth + col) * 4] = color[0];
+               data[(row * cellWidth + col) * 4 + 1] = color[1];
+               data[(row * cellWidth + col) * 4 + 2] = color[2];
+               data[(row * cellWidth + col) * 4 + 3] = 255;
+           }
+        }
+    }
+    ctx.putImageData(image_data, 0, 0);
 }
 
 function effect_timeMachine (keyframe, ctx, cellWidth, cellHeight) {
-    const parentLayerRGBA = getImageDataFourDimension(ctx, cellWidth, cellHeight)
-    secondLayerImageData = restoreUint8ClampedArray(
-        parentLayerRGBA.map(function(element, index, array) {
-            return index % 40 < 40 * keyframe ? hsvToRgb(keyframe * 360 * 4 % 360 + 180, 1, 1).concat(255) : element;
-        })
-    )
-    secondLayer = new ImageData(secondLayerImageData, cellWidth, cellHeight)
-    ctx.putImageData(secondLayer, 0, 0)
+    var image_data = ctx.getImageData(0, 0, cellWidth, cellHeight);
+    var data = image_data.data;
+    for (var row = 0; row < (cellHeight * cellWidth * 4); row = row + 4) {
+        if ((row / 4) % 40 < 40 * keyframe) {
+            var color = hsvToRgb(keyframe * 360 * 4 % 360 + 180, 1, 1);
+            data[row] = color[0];
+            data[row + 1] = color[1];
+            data[row + 2] = color[2];
+            data[row + 3] = 255;
+        }
+    }
+    ctx.putImageData(image_data, 0, 0);
 }
 
 function effect_dizzy (keyframe, ctx, cellWidth, cellHeight) {
-    const parentLayerRGBA = getImageDataFourDimension(ctx, cellWidth, cellHeight)
-    secondLayerImageData = restoreUint8ClampedArray(
-      parentLayerRGBA.map(function(element, index, array) {
-          return (index+(keyframe*40)) % 40 < 40 && (index+(keyframe*40)) % 40 > 20 ? hsvToRgb(keyframe * 360 * 4 % 360 + 180, 1, 1).concat(255) : element;
-      })
-    )
-    secondLayer = new ImageData(secondLayerImageData, cellWidth, cellHeight)
-    ctx.putImageData(secondLayer, 0, 0)
+    var image_data = ctx.getImageData(0, 0, cellWidth, cellHeight);
+    var data = image_data.data;
+    for (var row = 0; row < (cellHeight * cellWidth * 4); row = row + 4) {
+        if ((row / 4+(keyframe * 40)) % 40 < 40 && (row / 4 + (keyframe * 40)) % 40 > 20) {
+            var color = hsvToRgb(keyframe * 360 * 4 % 360 + 180, 1, 1);
+            data[row] = color[0];
+            data[row + 1] = color[1];
+            data[row + 2] = color[2];
+            data[row + 3] = 255;
+        }
+    }
+    ctx.putImageData(image_data, 0, 0);
 }
 
 function animation_scroll (keyframe, ctx, image, offsetH, offsetV, width, height, cellWidth, cellHeight) {

--- a/megamoji.js
+++ b/megamoji.js
@@ -466,32 +466,6 @@ function render_result_cell (image, offsetH, offsetV, width, height, animation, 
     }
 }
 
-//親レイヤーからピクセル情報を取得し、４次元を持つ配列として返す([R,G,B,Alpha])
-function getImageDataFourDimension(ctx, cellWidth, cellHeight) {
-    return ctx.getImageData(0, 0, cellWidth, cellHeight).data.reduce(function(previous, current) {
-        const enDivide = previous[previous.length - 1]
-        if (enDivide.length === 4) {
-            previous.push([current])
-            return previous
-        }
-        enDivide.push(current)
-        return previous
-    },[[]])
-}
-
-//4次元の配列を1次元に戻し、Uint8ClampedArray型で返す
-function restoreUint8ClampedArray (origin) {
-    return(
-        new Uint8ClampedArray(
-            origin.reduce( //一次元に戻す
-                function(accumulator, currentValue) {
-                    return accumulator.concat(currentValue);
-                }, []
-            )
-        )
-    )
-}
-
 //from https://qiita.com/hachisukansw/items/633d1bf6baf008e82847
 function hsvToRgb(H,S,V) {
     //https://en.wikipedia.org/wiki/HSL_and_HSV#From_HSV


### PR DESCRIPTION
# 作成例
### チリチリ
![tiritiri](https://user-images.githubusercontent.com/16838187/42082797-eab744ae-7bc3-11e8-8b92-c665812efe76.gif)

### ストライプ
![default](https://user-images.githubusercontent.com/16838187/42082803-ee8956e4-7bc3-11e8-8935-55b69ac56320.gif)

### タイムマシン
![default](https://user-images.githubusercontent.com/16838187/42082806-f02ba92a-7bc3-11e8-8979-425edda45b8e.gif)

### ネオンチリチリガタガタ
![default](https://user-images.githubusercontent.com/16838187/42082809-f1d05ba4-7bc3-11e8-984c-0272db8abe6d.gif)

### ブラーストライプ
![default](https://user-images.githubusercontent.com/16838187/42082810-f343446a-7bc3-11e8-9698-2bc91500c6d9.gif)

### めまいぐるぐる
![default](https://user-images.githubusercontent.com/16838187/42082813-f5836d2c-7bc3-11e8-8457-253300c0b58d.gif)

### 川
![default](https://user-images.githubusercontent.com/16838187/42082818-f7b533e6-7bc3-11e8-84ab-397632736b4a.gif)

### いろいろ
![default](https://user-images.githubusercontent.com/16838187/42082827-fc3c6812-7bc3-11e8-9120-62a549ffec10.gif)

## おもしろいとこ
背景色変更や既存エフェクトと共存できる。
新規エフェクト同士も組み合わせ可能。
`ストライプ`や`チリチリ`は内部的に透過度をいじることで
ブラーが広がっていくような感じにしている

## 技術的なところ
色情報をピクセルごとに取得して、mapでいろいろ変えて
元レイヤーに転写している。  

`ctx.getImageData`で全ドットの色情報を取得。
そのままでは[R,G,B,Alpha,R,G,B,Alpha,R,G,B,Alpha]　と一次元の配列で扱いにくいので
`ctx.getImageData(0, 0, cellWidth, cellHeight).data.reduce`で
`[[R,G,B,Alpha],[R,G,B,Alpha],[R,G,B,Alpha]]`と4次元の形に加工している。
この色情報をmapでいろいろ加工した後、

最終的に一次元に戻して`Uint8ClampedArray`型に戻している
`new ImageData`で画像化し、ctx.putImageDataで親に転写している





