### PR TITLE
GIFアニメーションの拡張子がundefinedになる問題を修正した

### DIFF
--- a/src/gifworker.ts
+++ b/src/gifworker.ts
@@ -13,6 +13,6 @@ ctx.addEventListener("message", (msg) => {
     encoder.writeFrame(index, width, height, { palette, delay, transparent });
   } else if (msg.data.finish) {
     encoder.finish();
-    ctx.postMessage(new Blob([encoder.bytes()]));
+    ctx.postMessage(new Blob([encoder.bytes()], { type: "image/gif" }));
   }
 });


### PR DESCRIPTION
GIFアニメーションとして出力された絵文字をダウンロードしたところ、ファイルがmegamoji.gifではなくmegamoji.undefinedとして出力されていました。

拡張子の付与にはBlobのtypeを利用していますが、GIFEncoderでエンコードしたものをBlobに入れるときにtypeの指定がなかったので追加しました。