### PR TITLE
Update transparent default setting

### DIFF
--- a/src/components/cards/Target.vue
+++ b/src/components/cards/Target.vue
@@ -109,7 +109,7 @@ export default defineComponent({
         easing: easings[0],
         duration: SPEED_OPTIONS[2].value,
         backgroundColor: "#ffffff",
-        transparent: false,
+        transparent: true,
       },
       showDetails: false,
       devMode: false,


### PR DESCRIPTION
# 概要
デフォルトでは透過がチェックされていないため、スタンプを作る時に毎回透過をチェックする手間が発生している。
デフォルトで透過がチェックされるように変更しました。
（もう一つの有名な[絵文字ジェネレーター](https://emoji-gen.ninja/)ではデフォルトで透過になっている）

![image](https://user-images.githubusercontent.com/80532711/231932838-bc06a1e3-64fa-47ea-888d-40ba136f623a.png)

# 懸念点
透過はアニメgifで非推奨なため、デフォルトのままでアニメgifを作ると意図しないスタンプが作られてしまう懸念があります。
ただアニメgifのスタンプよりもテキストのスタンプを作る機会が多いと思われます。

# 備考
初めてContributeさせていただきます。間違いがありましたらご指摘お願いいたします。