### PR TITLE
最後のframeを先頭に移動して、アニメーション非対応の環境でも文字を読めるようにする

### DIFF
--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -126,6 +126,30 @@ export const cutoutCanvasIntoCells = (
   return cells;
 };
 
+/* Determine if canvas is blank. */
+export const isCanvasBlank = (source: HTMLCanvasElement): boolean => {
+  const ctx = source.getContext("2d");
+  if (!ctx) {
+    throw new Error("Failed to get rendering context.");
+  }
+
+  const { data } = ctx.getImageData(0, 0, source.width, source.height);
+  const [firstR, firstG, firstB, firstA] = data;
+
+  for (let i = 0; i < data.length; i += 4) {
+    if (
+      data[i] !== firstR
+      || data[i + 1] !== firstG
+      || data[i + 2] !== firstB
+      || data[i + 3] !== firstA
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 /* Create an img object, set src attr to the specified url, and return it. */
 export const urlToImg = (url: string, cb: (img: HTMLImageElement) => void): void => {
   const img = document.createElement("img");

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -144,7 +144,7 @@ function renderAllCellsFixedSize(
     )));
   } else {
     /* instantiate GIF encoders for each cells */
-    const encoders = [];
+    const encoders: Worker[][] = [];
     for (let y = 0; y < vCells; y += 1) {
       const row = [];
       for (let x = 0; x < hCells; x += 1) {
@@ -154,7 +154,7 @@ function renderAllCellsFixedSize(
     }
     const delayPerFrame = 1000 / framerate;
     const frames = [...Array(framecount).keys()].map((i) => {
-      const keyframe = animationInvert ? 1 - easing(i / framecount) : easing(i / framecount)
+      const keyframe = animationInvert ? 1 - easing(i / framecount) : easing(i / framecount);
       return renderFrameUncut(
         keyframe,
         image,
@@ -180,7 +180,7 @@ function renderAllCellsFixedSize(
         frames.unshift(lastFrame);
       }
     }
-    for (const frame of frames) {
+    frames.forEach((frame) => {
       const imgCells = cutoutCanvasIntoCells(
         frame,
         0,
@@ -215,7 +215,7 @@ function renderAllCellsFixedSize(
           });
         }
       }
-    }
+    });
     return Promise.all<Blob[]>(encoders.map((row) => Promise.all<Blob>(row.map((cell) => (
       new Promise((resolve) => {
         cell.addEventListener("message", (res) => {

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -153,8 +153,14 @@ function renderAllCellsFixedSize(
       encoders.push(row);
     }
     const delayPerFrame = 1000 / framerate;
-    for (let i = 0; i < framecount; i += 1) {
-      const keyframe = animationInvert ? 1 - easing(i / framecount) : easing(i / framecount);
+    const keyframes = [...Array(framecount).keys()].map((i) => (
+      animationInvert ? 1 - easing(i / framecount) : easing(i / framecount)
+    ));
+    const lastKeyframe = keyframes.pop();
+    if (lastKeyframe !== undefined) {
+      keyframes.unshift(lastKeyframe);
+    }
+    for (const keyframe of keyframes) {
       const frame = renderFrameUncut(
         keyframe,
         image,

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -1,6 +1,6 @@
 import { Animation, Effect, WebGLEffect, Easing } from "../types";
 import { webglApplyEffects, webglInitialize } from "./webgl";
-import { cropCanvas, cutoutCanvasIntoCells } from "./canvas";
+import { cropCanvas, cutoutCanvasIntoCells, isCanvasBlank } from "./canvas";
 
 const webglEnabled = webglInitialize();
 
@@ -153,15 +153,9 @@ function renderAllCellsFixedSize(
       encoders.push(row);
     }
     const delayPerFrame = 1000 / framerate;
-    const keyframes = [...Array(framecount).keys()].map((i) => (
-      animationInvert ? 1 - easing(i / framecount) : easing(i / framecount)
-    ));
-    const lastKeyframe = keyframes.pop();
-    if (lastKeyframe !== undefined) {
-      keyframes.unshift(lastKeyframe);
-    }
-    for (const keyframe of keyframes) {
-      const frame = renderFrameUncut(
+    const frames = [...Array(framecount).keys()].map((i) => {
+      const keyframe = animationInvert ? 1 - easing(i / framecount) : easing(i / framecount)
+      return renderFrameUncut(
         keyframe,
         image,
         offsetH,
@@ -179,6 +173,14 @@ function renderAllCellsFixedSize(
         framecount,
         transparent ? "rgba(0, 0, 0, 0)" : backgroundColor,
       );
+    });
+    if (isCanvasBlank(frames[0])) {
+      const lastFrame = frames.pop();
+      if (lastFrame !== undefined) {
+        frames.unshift(lastFrame);
+      }
+    }
+    for (const frame of frames) {
       const imgCells = cutoutCanvasIntoCells(
         frame,
         0,


### PR DESCRIPTION
https://github.com/zk-phi/MEGAMOJI/issues/339

最後のframeを先頭に移動することで、アニメーション非対応の環境でも文字を読めるようにしました。
ループ画像のため、frameをローテーションすることの問題は少ないと思います。

[![Image from Gyazo](https://i.gyazo.com/7c56d9dd10910e4674e7140324fecdb7.gif)](https://gyazo.com/7c56d9dd10910e4674e7140324fecdb7)
[![Image from Gyazo](https://i.gyazo.com/1b7faadc412a943fef53998336990876.png)](https://gyazo.com/1b7faadc412a943fef53998336990876)
