### PR TITLE
norinoriエフェクトを修正

### DIFF
--- a/src/effects/norinori.ts
+++ b/src/effects/norinori.ts
@@ -17,7 +17,7 @@ const effectNorinori: Effect = (keyframe, ctx, cellWidth, cellHeight) => {
     0,
     sign * ratio,
     1 - ratio,
-    -sign * ratio * cellWidth * 3 / 4,
+    -sign * ratio * cellHeight * 3 / 4,
     ratio * cellHeight * 3 / 4,
   );
 };


### PR DESCRIPTION
#346 で計算ミスがあったので修正します。
絵文字の縦横比が異なる場合に影響します。
### before
![hoge](https://github.com/zk-phi/MEGAMOJI/assets/133759614/2c81c08d-df10-4434-8d01-e0285758a184)
![hoge (1)](https://github.com/zk-phi/MEGAMOJI/assets/133759614/2865b615-53ec-4415-af68-818afbca27cc)
### after
![hoge (2)](https://github.com/zk-phi/MEGAMOJI/assets/133759614/525b52bb-9751-442a-abcf-e6e4b50b7f37)
![hoge (3)](https://github.com/zk-phi/MEGAMOJI/assets/133759614/6e6e56d2-bae9-408b-ae19-bff6038aa7f4)
